### PR TITLE
Docs: align color palette with site

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3,9 +3,9 @@
   "theme": "mint",
   "name": "SkillDock Docs",
   "colors": {
-    "primary": "#0F766E",
-    "light": "#14B8A6",
-    "dark": "#115E59"
+    "primary": "#1E90FF",
+    "light": "#67B8FF",
+    "dark": "#0A0A0A"
   },
   "favicon": "/favicon.svg",
   "navigation": {


### PR DESCRIPTION
Summary:
- set primary color to #1E90FF, light accent to #67B8FF, dark background to #0A0A0A to match SkillDock site palette

Issue: none (palette alignment request)